### PR TITLE
Pass variables to replace tokens in query

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mapnik-vector-tile",
-    "version": "1.2.2",
+    "version": "1.2.2-cdb1",
     "description": "Mapnik Vector Tile API",
     "main": "include_dirs.js",
     "repository"   :  {

--- a/src/vector_tile_layer.hpp
+++ b/src/vector_tile_layer.hpp
@@ -95,7 +95,8 @@ public:
                double scale_factor,
                double scale_denom,
                int offset_x,
-               int offset_y)
+               int offset_y,
+               mapnik::attributes const& vars)
         : valid_(true),
           ds_(lay.datasource()),
           target_proj_(map.srs(), true),
@@ -106,7 +107,7 @@ public:
           layer_extent_(calc_extent(tile_size)),
           target_buffered_extent_(calc_target_buffered_extent(tile_extent_bbox, buffer_size, lay, map)),
           source_buffered_extent_(calc_source_buffered_extent()),
-          query_(calc_query(scale_factor, scale_denom, tile_extent_bbox, lay)),
+          query_(calc_query(scale_factor, scale_denom, tile_extent_bbox, lay, vars)),
           view_trans_(layer_extent_, layer_extent_, tile_extent_bbox, offset_x, offset_y),
           empty_(true),
           painted_(false)
@@ -221,7 +222,8 @@ public:
     mapnik::query calc_query(double scale_factor,
                              double scale_denom,
                              mapnik::box2d<double> const& tile_extent_bbox,
-                             mapnik::layer const& lay)
+                             mapnik::layer const& lay,
+                             mapnik::attributes const& vars)
     {
         // Adjust the scale denominator if required
         if (scale_denom <= 0.0)
@@ -285,6 +287,7 @@ public:
                 q.add_property_name(desc.get_name());
             }
         }
+        q.set_variables(vars);
         return q;
     }
 

--- a/src/vector_tile_processor.hpp
+++ b/src/vector_tile_processor.hpp
@@ -6,6 +6,7 @@
 #include <mapnik/image_scaling.hpp>
 #include <mapnik/layer.hpp>
 #include <mapnik/map.hpp>
+#include <mapnik/attribute.hpp>
 #include <mapnik/request.hpp>
 #include <mapnik/util/noncopyable.hpp>
 
@@ -46,9 +47,10 @@ private:
     bool multi_polygon_union_;
     bool process_all_rings_;
     std::launch threading_mode_;
+    mapnik::attributes vars_;
 
 public:
-    processor(mapnik::Map const& map)
+    processor(mapnik::Map const& map, mapnik::attributes const& vars = mapnik::attributes())
         : m_(map),
           image_format_("webp"),
           scale_factor_(1.0),
@@ -59,7 +61,8 @@ public:
           strictly_simple_(true),
           multi_polygon_union_(false),
           process_all_rings_(false),
-          threading_mode_(std::launch::deferred) {}
+          threading_mode_(std::launch::deferred),
+          vars_(vars) {}
 
     MAPNIK_VECTOR_INLINE void update_tile(tile & t,
                                           double scale_denom = 0.0,

--- a/src/vector_tile_processor.ipp
+++ b/src/vector_tile_processor.ipp
@@ -14,6 +14,7 @@
 #include <mapnik/image_scaling.hpp>
 #include <mapnik/layer.hpp>
 #include <mapnik/map.hpp>
+#include <mapnik/attribute.hpp>
 #include <mapnik/geometry_transform.hpp>
 
 // boost
@@ -283,7 +284,8 @@ MAPNIK_VECTOR_INLINE void processor::update_tile(tile & t,
                              scale_factor_,
                              scale_denom,
                              offset_x,
-                             offset_y);
+                             offset_y,
+                             vars_);
         if (!tile_layers.back().is_valid())
         {
             t.add_empty_layer(lay.name());


### PR DESCRIPTION
This fixes #218

What this does:
- it optionally adds a new member `mapnik::attributes vars` to the mvt processor. It is a pretty open data [structure](https://github.com/mapnik/mapnik/blob/v3.0.12/include/mapnik/attribute.hpp#L73) used in other parts of mapnik & friends to pass tokens along.
- it is passed by `processor::update_tile` to the `tile_layer`, so that it can set the variables of its associated query from there (an empty unordered map if not passed to the processor).

(thanks @Algunenano for the advice on the constructor)

@Algunenano @javisantana can you please take a look?